### PR TITLE
Fix potential panics from unwrap() calls

### DIFF
--- a/src/gl_renderer.rs
+++ b/src/gl_renderer.rs
@@ -129,12 +129,12 @@ impl GlRenderer {
             .make_current(&gl_surface)
             .map_err(|e| format!("Failed to make current: {:?}", e))?;
         gl::load_with(|symbol| {
-            let symbol = std::ffi::CString::new(symbol).unwrap();
+            let symbol = std::ffi::CString::new(symbol).expect("OpenGL symbol name contains null byte");
             gl_display.get_proc_address(symbol.as_c_str()).cast()
         });
         let version = unsafe { CStr::from_ptr(gl::GetString(gl::VERSION) as *const _).to_string_lossy() };
         log::info!("OpenGL Version: {}", version);
-        if let Err(e) = gl_surface.set_swap_interval(&gl_context, SwapInterval::Wait(NonZeroU32::new(1).unwrap())) {
+        if let Err(e) = gl_surface.set_swap_interval(&gl_context, SwapInterval::Wait(unsafe { NonZeroU32::new_unchecked(1) })) {
             log::warn!("Error setting vsync: {:?}", e);
         }
         let shader_program = unsafe { Self::compile_program(VERTEX_SHADER_SOURCE, FRAGMENT_SHADER_SOURCE)? };
@@ -158,7 +158,7 @@ impl GlRenderer {
     unsafe fn compile_program(vertex_source: &str, fragment_source: &str) -> Result<u32, String> {
         let mut success = 0;
         let vertex_shader = gl::CreateShader(gl::VERTEX_SHADER);
-        let c_str = CString::new(vertex_source).unwrap();
+        let c_str = CString::new(vertex_source).map_err(|e| format!("Failed to create CString: {}", e))?;
         gl::ShaderSource(vertex_shader, 1, &c_str.as_ptr(), ptr::null());
         gl::CompileShader(vertex_shader);
         gl::GetShaderiv(vertex_shader, gl::COMPILE_STATUS, &mut success);
@@ -168,7 +168,7 @@ impl GlRenderer {
             return Err(format!("Vertex shader compilation failed: {}", String::from_utf8_lossy(&log)));
         }
         let fragment_shader = gl::CreateShader(gl::FRAGMENT_SHADER);
-        let c_str = CString::new(fragment_source).unwrap();
+        let c_str = CString::new(fragment_source).map_err(|e| format!("Failed to create CString: {}", e))?;
         gl::ShaderSource(fragment_shader, 1, &c_str.as_ptr(), ptr::null());
         gl::CompileShader(fragment_shader);
         gl::GetShaderiv(fragment_shader, gl::COMPILE_STATUS, &mut success);
@@ -222,10 +222,11 @@ impl GlRenderer {
         if width > 0 && height > 0 {
             self.width = width;
             self.height = height;
+            // Safety: We've checked that width > 0 and height > 0 above
             self.gl_surface.resize(
                 &self.gl_context,
-                NonZeroU32::new(width).unwrap(),
-                NonZeroU32::new(height).unwrap(),
+                unsafe { NonZeroU32::new_unchecked(width) },
+                unsafe { NonZeroU32::new_unchecked(height) },
             );
             unsafe {
                 gl::Viewport(0, 0, width as i32, height as i32);

--- a/src/state.rs
+++ b/src/state.rs
@@ -256,7 +256,6 @@ impl XdgShellHandler for AppState {
     fn maximize_request(&mut self, surface: smithay::wayland::shell::xdg::ToplevelSurface) {
         println!("*** HIT MAXIMIZE REQUEST ***");
         log::info!("Maximize Request: {:?}", surface.wl_surface().id());
-        let current_mode = self.output.current_mode().unwrap();
         log::info!(
             "DEBUG MAXIMIZE: self.width={}, self.height={}, self.scale_factor={}",
             self.width,


### PR DESCRIPTION
## Problem
Found several issues where `.unwrap()` could cause panics:

1. **state.rs line 259**: Dead code that obtained `current_mode` with `unwrap()` but never used it
   ```rust
   let current_mode = self.output.current_mode().unwrap();
   ```
   This variable was assigned but never used - the code uses `self.width` and `self.height` instead. The `unwrap()` could panic if no current mode exists.

2. **gl_renderer.rs**: Multiple `unwrap()` calls that could fail:
   - `CString::new(symbol).unwrap()` - panics if symbol contains null byte
   - `NonZeroU32::new(1).unwrap()` - redundant unwrap (1 is always non-zero)
   - `CString::new(shader_source).unwrap()` - panics if source contains null byte
   - `NonZeroU32::new(width).unwrap()` - technically safe due to `width > 0` check but still uses unwrap

## Solution
- Remove the unused `current_mode` variable in `maximize_request`
- Replace `unwrap()` with `expect()` for better error messages
- Use `unsafe { NonZeroU32::new_unchecked(1) }` for the constant value (more efficient)
- Use `?` operator with proper error messages for `CString::new()` in shader compilation
- Add safety comment and use `new_unchecked` in `resize()` since we check bounds first

## Impact
- Removes dead code
- Improves error messages when errors occur
- Makes the code more robust and idiomatic

🤖 Generated with [Claude Code](https://claude.com/claude-code)