### PR TITLE
User pressing the escape key should no longer exit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use log::info;
 use std::sync::Arc;
 use winit::event::{ElementState, Event, KeyEvent, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
-use winit::keyboard::PhysicalKey;
 use smithay::input::keyboard::FilterResult;
 use smithay::input::pointer::{ButtonEvent, MotionEvent};
 use smithay::reexports::wayland_server::Resource;
@@ -207,9 +206,7 @@ fn main() {
                     WindowEvent::CloseRequested => target.exit(),
                     WindowEvent::KeyboardInput { event: KeyEvent { state: el_state, physical_key, .. }, .. } => {
                         if let winit::keyboard::PhysicalKey::Code(key_code) = physical_key {
-                            use winit::keyboard::KeyCode;
                             match key_code {
-                                KeyCode::Escape => target.exit(),
                                 _ => {
                                      use smithay::backend::input::KeyState;
                                      use smithay::input::keyboard::Keycode;  


### PR DESCRIPTION
### Observation

When getting started with cocoa-way everything seems to work fine but as soon as you start trying to use a `weston-terminal` and open vim you often will hit escape immediately upon trying to work with a file. This closes the compositor window without warning and is unexpected. As a new user this seemed like the compositor was crashing and not working as designed.

After removing this matcher and using it for a bit I found I was able to still comfortably use the ordinary macOS close window flows such as Cmd-Q or click the red close button on the title bar worked as expected.

### Change

In the keycode matcher, remove the match where we exit the application. The now unused import was also cleaned up.

### Environment

M3 Pro, macOS 26.3